### PR TITLE
Update station logo path

### DIFF
--- a/bbc.html
+++ b/bbc.html
@@ -157,7 +157,7 @@ function serviceData(data) {
   var key = s.key;
   var type = s.type;
   var which = type == 'tv' ? 'WATCH' : 'LISTEN';
-  var path = 'http://www.bbc.co.uk/iplayer/img/station_logos/'+key+'.png';
+  var path = 'http://static.bbci.co.uk/radio/156/1.81.1/img/logos/v2/'+key+'_alt_colour.svg';
   var link = "chrome.tabs.create({url: 'http://www.bbc.co.uk/iplayer/"+type+"/"+key+"'});"; 
   var islive = 'islive';
   var live_str = ''; 


### PR DESCRIPTION
The logos and most images are broken:

![broken logos and images](https://cloud.githubusercontent.com/assets/1324225/21586386/581a299a-d0d9-11e6-87a9-7c4543bd2ba8.png)

Old, 404 paths are like: http://www.bbc.co.uk/iplayer/img/station_logos/bbc_radio_four_extra.png

The logos on http://www.bbc.co.uk/radio#stations are like: http://static.bbci.co.uk/radio/156/1.81.1/img/logos/v2/bbc_radio_four_extra_alt_colour.svg

Note: I've not tested these locally, and this doesn't include a fix for television, so consider this more of a bug report :)